### PR TITLE
Logo goes to dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@
 
 .byebug_history
 
-.env
+/.env

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,7 +16,7 @@
 <head> 
     <div class = "header-container">
     	<div class = "logo-container">
-    		<%= link_to image_tag("logo2.png"), root_path %>
+    		<%= link_to image_tag("logo2.png"), "/dashboard" %>
     	</div>
     </div>
 </head>


### PR DESCRIPTION
Clicking on the logo after logging in goes to the dashboard, not home screen. Only way you can reach home screen after login is if you log out. 